### PR TITLE
fixes completions json parsing

### DIFF
--- a/subclim_plugin.py
+++ b/subclim_plugin.py
@@ -454,7 +454,7 @@ class JavaCompletions(sublime_plugin.EventListener):
 
     def to_proposals(self, eclim_output):
         proposals = []
-        completions = json.loads(eclim_output)
+        completions = json.loads(eclim_output)["completions"]
         for c in completions:
             if not "<br/>" in c['info']:  # no overloads
                 proposals.append(CompletionProposal(c['info'], c['completion']))


### PR DESCRIPTION
Hi, completions crashed for me in Sublime 2 with eclim 1.7.6 and the latest subclim. This patch seems to fix it and completions are now working properly. 

P.S: Thank you for Subclim! Not having to use Eclipse all day long is liberating!
